### PR TITLE
update deprecated flutter_launcher_icons usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ That said, I may consider creating branches with my architecture and state manag
 
    Then we'll auto-generate your app launcher icons using [flutter_launcher_icons](https://pub.dev/packages/flutter_launcher_icons) package.
    * Copy the image you want to make your launcher icons out of to `assets/icon/icon.png.`
-   * Now run `flutter pub run flutter_launcher_icons:main`. This command will auto-generate Android and iOS launcher icons from the PNG file for the different DPIs and place them in their respective resource directories.
+   * Now run `flutter pub run flutter_launcher_icons`. This command will auto-generate Android and iOS launcher icons from the PNG file for the different DPIs and place them in their respective resource directories.
 
    **NOTE**: Check the [package documentation](https://pub.dev/packages/flutter_launcher_icons#book-guide) for more configuration options on generating launcher icons and update your `pubspec. yaml` accordingly.
    For example, you may want different icons for different platforms since Android allows you to use a transparent icon and iOS doesn't.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,7 +44,7 @@ dev_dependencies:
   # screenshots
   # test: any
 
-flutter_icons:
+flutter_launcher_icons:
   android: "launcher_icon"
   ios: true
   image_path: "assets/icon/icon.png"


### PR DESCRIPTION
Hi @danvick 

I was very interested in your flutter template so I gave it a try.
When I was running your `README.md` instructions I noticed the deprecated message while running the command for `fluttter_launcher_icons:main`.

Output with old `flutter_launcher_icons` configuration:

```
PS D:\git\flutter_boilerplate> flutter pub run flutter_launcher_icons:main
This command is deprecated and replaced with "flutter pub run flutter_launcher_icons"
  ════════════════════════════════════════════
     FLUTTER LAUNCHER ICONS (v0.13.1)
  ════════════════════════════════════════════


⚠ Warning: flutter_icons has been deprecated please use flutter_launcher_icons instead in your yaml files
• Creating default icons Android
• Adding a new Android launcher icon

WARNING: Icons with alpha channel are not allowed in the Apple App Store.
Set "remove_alpha_ios: true" to remove it.

• Overwriting default iOS launcher icon with new icon
No platform provided

✓ Successfully generated launcher icons
```

I hope this helps to keep this template up to date and clean.

With best regards, Timon